### PR TITLE
Updated if check on line 65 to use AND instead of OR

### DIFF
--- a/Pod/Classes/UIImage/UIImage+Network.m
+++ b/Pod/Classes/UIImage/UIImage+Network.m
@@ -62,7 +62,7 @@
             static NSUInteger numberOfOpenThreads = 0;
             
             // Prevent too many images from loading at once (causes UI framerate loss)
-            if(numberOfOpenThreads < MAX_IMAGE_DOWNLOAD_THREAD || (![[self imageQueue] containsObject:urlPath] && allowsCaching))
+            if(numberOfOpenThreads < MAX_IMAGE_DOWNLOAD_THREAD && (![[self imageQueue] containsObject:urlPath] && allowsCaching))
             {
                 // Add url to queue; preventing downloading the same image twice
                 if(allowsCaching)


### PR DESCRIPTION
If the number of open threads is less than `MAX_IMAGE_DOWNLOAD_THREAD`, the if check will always succeed, regardless of if the image is already in the download queue (`imageQueue`).
